### PR TITLE
Csv headers

### DIFF
--- a/lib/stat_tracker.rb
+++ b/lib/stat_tracker.rb
@@ -6,9 +6,9 @@ class StatTracker
   attr_reader :all_teams, :all_games, :all_game_teams
 
   def initialize(team_array, game_array, game_teams_array)
-    @all_teams = team_array[1..-1]
-    @all_games = game_array[1..-1]
-    @all_game_teams = game_teams_array[1..-1]
+    @all_teams = team_array
+    @all_games = game_array
+    @all_game_teams = game_teams_array
   end
 
   def self.from_csv(file_paths)
@@ -23,7 +23,7 @@ class StatTracker
 
 
   def self.generate_data(location ,obj_type, array)
-    CSV.foreach(location) do |row|
+    CSV.foreach(location, :headers => true) do |row|
       array << obj_type.new(row)
     end
   end

--- a/test/game_teams_sample.csv
+++ b/test/game_teams_sample.csv
@@ -1,0 +1,10 @@
+game_id,team_id,HoA,result,settled_in,head_coach,goals,shots,tackles,pim,powerPlayOpportunities,powerPlayGoals,faceOffWinPercentage,giveaways,takeaways
+2012030221,3,away,LOSS,OT,John Tortorella,2,8,44,8,3,0,44.8,17,7
+2012030221,6,home,WIN,OT,Claude Julien,3,12,51,6,4,1,55.2,4,5
+2012030222,3,away,LOSS,REG,John Tortorella,2,9,33,11,5,0,51.7,1,4
+2012030222,6,home,WIN,REG,Claude Julien,3,8,36,19,1,0,48.3,16,6
+2012030223,6,away,WIN,REG,Claude Julien,2,8,28,6,0,0,61.8,10,7
+2012030223,3,home,LOSS,REG,John Tortorella,1,6,37,2,2,0,38.2,7,9
+2012030224,6,away,WIN,OT,Claude Julien,3,10,24,8,4,2,53.7,8,6
+2012030224,3,home,LOSS,OT,John Tortorella,2,8,40,8,4,1,46.3,9,7
+2012030225,3,away,LOSS,REG,John Tortorella,1,7,25,13,2,1,50.9,5,3

--- a/test/games_sample.csv
+++ b/test/games_sample.csv
@@ -1,0 +1,20 @@
+game_id,season,type,date_time,away_team_id,home_team_id,away_goals,home_goals,venue,venue_link
+2012030221,20122013,Postseason,5/16/13,3,6,2,3,Toyota Stadium,/api/v1/venues/null
+2012030222,20122013,Postseason,5/19/13,3,6,2,3,Toyota Stadium,/api/v1/venues/null
+2012030223,20122013,Postseason,5/21/13,6,3,2,1,BBVA Stadium,/api/v1/venues/null
+2012030224,20122013,Postseason,5/23/13,6,3,3,2,BBVA Stadium,/api/v1/venues/null
+2012030225,20122013,Postseason,5/25/13,3,6,1,3,Toyota Stadium,/api/v1/venues/null
+2012030311,20122013,Postseason,6/2/13,6,5,3,0,Children's Mercy Park,/api/v1/venues/null
+2012030312,20122013,Postseason,6/4/13,6,5,4,1,Children's Mercy Park,/api/v1/venues/null
+2012030313,20122013,Postseason,6/6/13,5,6,1,2,Toyota Stadium,/api/v1/venues/null
+2012030314,20122013,Postseason,6/8/13,5,6,0,1,Toyota Stadium,/api/v1/venues/null
+2012030231,20122013,Postseason,5/16/13,17,16,1,2,Gillette Stadium,/api/v1/venues/null
+2012030232,20122013,Postseason,5/18/13,17,16,2,1,Gillette Stadium,/api/v1/venues/null
+2012030233,20122013,Postseason,5/20/13,16,17,1,3,Dignity Health Sports Park,/api/v1/venues/null
+2012030234,20122013,Postseason,5/24/13,16,17,0,2,Dignity Health Sports Park,/api/v1/venues/null
+2012030235,20122013,Postseason,5/26/13,17,16,1,2,Gillette Stadium,/api/v1/venues/null
+2012030236,20122013,Postseason,5/28/13,16,17,2,3,Dignity Health Sports Park,/api/v1/venues/null
+2012030237,20122013,Postseason,5/30/13,17,16,1,2,Gillette Stadium,/api/v1/venues/null
+2012030121,20122013,Postseason,5/2/13,9,8,2,2,Red Bull Arena,/api/v1/venues/null
+2012030122,20122013,Postseason,5/3/13,9,8,1,3,Red Bull Arena,/api/v1/venues/null
+2012030123,20122013,Postseason,5/5/13,8,9,1,4,Yankee Stadium,/api/v1/venues/null

--- a/test/stat_tracker_test.rb
+++ b/test/stat_tracker_test.rb
@@ -10,9 +10,9 @@ require 'csv'
 class StatTrackerTest < Minitest::Test
 
   def setup
-    game_path = './data/games.csv'
-    team_path = './data/teams.csv'
-    game_teams_path = './data/game_teams.csv'
+    game_path = './test/games_sample.csv'
+    team_path = './test/teams_sample.csv'
+    game_teams_path = './test/game_teams_sample.csv'
 
     @locations = {
       games: game_path,
@@ -22,13 +22,13 @@ class StatTrackerTest < Minitest::Test
     @stat_tracker = StatTracker.from_csv(@locations)
   end
 
-  def test_it_exists
+  def test_it_exists_and_attributes
     assert_instance_of StatTracker, @stat_tracker
   end
 
-  def test_for_all_made_data
-    assert_equal 32, @stat_tracker.all_teams.length
-    assert_equal 7441, @stat_tracker.all_games.length
-    assert_equal 14882, @stat_tracker.all_game_teams.length
+  def test_attributes
+    assert_equal Team, @stat_tracker.all_teams.first.class
+    assert_equal Game, @stat_tracker.all_games.first.class
+    assert_equal GameTeam, @stat_tracker.all_game_teams.first.class
   end
 end

--- a/test/teams_sample.csv
+++ b/test/teams_sample.csv
@@ -1,0 +1,10 @@
+team_id,franchiseId,teamName,abbreviation,Stadium,link
+1,23,Atlanta United,ATL,Mercedes-Benz Stadium,/api/v1/teams/1
+4,16,Chicago Fire,CHI,SeatGeek Stadium,/api/v1/teams/4
+26,14,FC Cincinnati,CIN,Nippert Stadium,/api/v1/teams/26
+14,31,DC United,DC,Audi Field,/api/v1/teams/14
+6,6,FC Dallas,DAL,Toyota Stadium,/api/v1/teams/6
+3,10,Houston Dynamo,HOU,BBVA Stadium,/api/v1/teams/3
+5,17,Sporting Kansas City,SKC,Children's Mercy Park,/api/v1/teams/5
+17,12,LA Galaxy,LA,Dignity Health Sports Park,/api/v1/teams/17
+28,29,Los Angeles FC,LFC,Banc of California Stadium,/api/v1/teams/28


### PR DESCRIPTION
Refactors stat_tracker removing the necessity for [1..-1] by using (headers => true)

Adds mock data for tests and changes data paths only for tests 



