### PR TITLE
Teams hash

### DIFF
--- a/lib/league_stat.rb
+++ b/lib/league_stat.rb
@@ -16,7 +16,7 @@ module LeagueStat
     best_offense = team_id_and_goals.max_by do |id, goals|
       goals
     end
-    all_teams.find {|team| best_offense[0] == team.team_id}.team_name
+    all_teams[best_offense[0]].team_name
   end
 
   def worst_offense

--- a/lib/stat_tracker.rb
+++ b/lib/stat_tracker.rb
@@ -10,26 +10,33 @@ class StatTracker
   include LeagueStat
   attr_reader :all_teams, :all_games, :all_game_teams
 
-  def initialize(team_array, game_array, game_teams_array)
-    @all_teams = team_array
+  def initialize(team_hash, game_array, game_teams_array)
+    @all_teams = team_hash
     @all_games = game_array
     @all_game_teams = game_teams_array
   end
 
   def self.from_csv(file_paths)
-    all_teams = Array.new
+    all_teams = Hash.new
     all_games = Array.new
     all_game_teams = Array.new
-    self.generate_data(file_paths[:teams], Team, all_teams)
+    self.generate_hash(file_paths[:teams], Team, all_teams)
     self.generate_data(file_paths[:games], Game, all_games)
     self.generate_data(file_paths[:game_teams], GameTeam, all_game_teams)
     self.new(all_teams, all_games, all_game_teams)
   end
 
 
-  def self.generate_data(location ,obj_type, array)
+  def self.generate_data(location, obj_type, array)
     CSV.foreach(location, headers: true) do |row|
       array << obj_type.new(row)
+    end
+  end
+
+  def self.generate_hash(location, obj_type, hash)
+    CSV.foreach(location, headers: true) do |row|
+      obj = obj_type.new(row)
+      hash[row[0]] = obj
     end
   end
 end

--- a/test/stat_tracker_test.rb
+++ b/test/stat_tracker_test.rb
@@ -27,7 +27,8 @@ class StatTrackerTest < Minitest::Test
   end
 
   def test_attributes
-    assert_equal Team, @stat_tracker.all_teams.first.class
+    assert_instance_of Hash, @stat_tracker.all_teams
+    assert_equal Team, @stat_tracker.all_teams.values.first.class
     assert_equal Game, @stat_tracker.all_games.first.class
     assert_equal GameTeam, @stat_tracker.all_game_teams.first.class
   end


### PR DESCRIPTION
In stat_tracker, a new class method to generate a hash that maps team_id to a team object is used in place of an array of teams. This allows us in `league_stats.rb` to use `all_teams[id].team_name` instead of `find`.

I created `self.generate_hash` in the same style as `self.generate_data` so that if we need to refactor all_games to pull the game_id, we can. 

I decided to generate the data directly from the CSV rather than the array created in `self.generate_data` to eliminate looping through all objects twice.